### PR TITLE
Setup Static Analysis and Linter for Flutter

### DIFF
--- a/frontend/search_cms/analysis_options.yaml
+++ b/frontend/search_cms/analysis_options.yaml
@@ -9,6 +9,13 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+# performs static analysis over all the dart files
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`
@@ -21,8 +28,16 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    # linter rules specified in the style guide
+    - lines_longer_than_80_chars
+    - curly_braces_in_flow_control_structures
+    - camel_case_types
+    - camel_case_extensions
+    - file_names
+    - package_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - directives_ordering
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
Add static analysis and a linter for Flutter code that works when 'flutter analyze' is run. 
The lint standard is set acording to the code style guide documented in the Wiki. 

This will work with the github runner and yml files in the .github/workflows/ directory
to run static analysis and auto linter.

Style Guide: https://github.com/UniversityOfSaskatchewanCMPT371/term-project-winter2026-team1/wiki/Style-Guide

Resolves #13, resolves #14.