### PR TITLE
Added nightly merge job to workflows

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -2,7 +2,11 @@ name: 'Nightly Merge'
 
 on:
   schedule:
+<<<<<<< HEAD
     - cron:  '0 0 * * *'
+=======
+    - cron:  '0 18 * * *'
+>>>>>>> 67ec139 (Added nightly merge job to workflows)
 
 jobs:
   nightly-merge:
@@ -19,8 +23,13 @@ jobs:
     - name: Nightly Merge
       uses: robotology/gh-action-nightly-merge@v1.5.2
       with:
+<<<<<<< HEAD
         stable_branch: 'main'
         development_branch: 'develop'
+=======
+        stable_branch: 'develop'
+        development_branch: 'main'
+>>>>>>> 67ec139 (Added nightly merge job to workflows)
         allow_ff: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a nightly merge that will move develop to main.

This DOES NOT involve any tests at the moment, the PR request to develop will be the  protector with all integration and unit test. This will simply a place holder until our develop -> main tests are done.


Issue: #49 
