### PR TITLE
Modified nightly to do a independent PR to merge develop to main

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -15,12 +15,20 @@ jobs:
       with:
         fetch-depth: 0 # Full clone necessary for proper merge
 
+    # Add versioning
+    - name: Set Version String
+      id: version
+      run: echo "DATE_VER=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
     # Uses a marketplace gh action that merges the develop to main, no need for testing yet.
-    - name: Nightly Merge
-      uses: robotology/gh-action-nightly-merge@v1.5.2
+    # This action creates a PR instead of doing a direct push
+    - name: Create Pull Request to Main
+      uses: peter-evans/create-pull-request@v6
       with:
-        stable_branch: 'develop'
-        development_branch: 'main'
-        allow_ff: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: nightly-merge-v${{ env.DATE_VER }}
+        base: main
+        title: 'Nightly Merge: v${{ env.DATE_VER }}'
+        body: 'Automated nightly merge for version ${{ env.DATE_VER }}. This PR will auto-merge once all status checks pass.'
+        commit-message: 'Automated nightly merge v${{ env.DATE_VER }}''
+        delete-branch: false
+  


### PR DESCRIPTION
-> Rather than automating the merge, we thought it was better to verify the test from develop to main before pushing it up. This will generate a daily PR that has to be manually accepted by two reviewers before pushing it up to main.
-> this will allow daily versioning and will act act as the skeleton for larger tests.
-> Goal is to eventually activate long term tests on this  PR so that we can verify full functionality before merging develop to main. As of writing, this does not activate long terms yet as they don't exist, this is the foundation for the nightly piece.

This is to resolve the bug #143 