### PR TITLE
Update nightly-merge.yml on Main

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -32,5 +32,4 @@ jobs:
         body: 'Automated nightly merge for version ${{ env.DATE_VER }}. This PR will auto-merge once all status checks pass.'
         commit-message: 'Automated nightly merge v${{ env.DATE_VER }}'
         delete-branch: false
-
   


### PR DESCRIPTION
Found bug where the PR from the bot sends it to main by default instead of develop. Fixed this by pointing it's ref to develop instead of main by default.

NOTE:

I am PRing directly to main due to this being a CI issue and not directly code based on the project. This is purely because I am the build master and modifying the CI running on main.