### PR TITLE
Desktop Nightly App CI Bug

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -1,14 +1,6 @@
 name: Flutter Desktop Nightly
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'frontend/search_cms/**'
-      - '.github/workflows/desktop-nightly.yml'
-  schedule:
-    # 06:00 UTC ≈ midnight / 11pm in SK depending on DST; adjust as you like
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 # Prevent overlapping runs fighting over the "nightly" tag/release


### PR DESCRIPTION
Temporarily disable the feature due to GitHub Actions failing run on `main`.

Closes #334.